### PR TITLE
Orphaned Listviews and Scrollbars

### DIFF
--- a/lib/widgets/molecules/asset_amount_field.dart
+++ b/lib/widgets/molecules/asset_amount_field.dart
@@ -142,6 +142,7 @@ class _AssetAmountFieldState extends State<AssetAmountField> {
   /// Allows selecting from the unit dropdown if [widget.allowEditingUnit] is true.
   Widget _buildUnitDisplay() {
     const double _fieldHeight = 36;
+    ScrollController _scrollController = ScrollController();
 
     return widget.showUnit
         ? widget.allowEditingUnit
@@ -159,7 +160,7 @@ class _AssetAmountFieldState extends State<AssetAmountField> {
                     childAlignment: Alignment.bottomLeft,
                     dropDownAlignment: Alignment.topCenter,
                     chevronIcon: widget.chevronIcon,
-                    dropdownChild: _buildUnitDropdownChild(),
+                    dropdownChild: _buildUnitDropdownChild(_scrollController),
                     selectedItem: widget.selectedUnit != null
                         ? Text(
                             formatAssetUnit(widget.selectedUnit),
@@ -199,7 +200,7 @@ class _AssetAmountFieldState extends State<AssetAmountField> {
   /// Builds the Unit dropdown widget.
   ///
   /// Allows user to select from a list of custom units, i.e. [UIConstants.assetUnitsList].
-  Widget _buildUnitDropdownChild() {
+  Widget _buildUnitDropdownChild(ScrollController _scrollController) {
     return Padding(
       padding: const EdgeInsets.only(left: 138.0),
       child: Container(
@@ -223,8 +224,10 @@ class _AssetAmountFieldState extends State<AssetAmountField> {
           removeTop: true,
           child: Scrollbar(
             thumbVisibility: true,
+            controller: _scrollController,
             child: ListView(
               padding: const EdgeInsets.all(0),
+              controller: _scrollController,
               children: UIConstants.assetUnitsList
                   .map(
                     (unit) => MaterialButton(

--- a/lib/widgets/molecules/asset_selection_field.dart
+++ b/lib/widgets/molecules/asset_selection_field.dart
@@ -47,6 +47,7 @@ class AssetSelectionField extends StatefulWidget {
 class _AssetSelectionFieldState extends State<AssetSelectionField> {
   /// True if asset dropdown needs to be displayed.
   bool showAssetDropdown = false;
+  final ScrollController _scrollController = ScrollController();
 
   @override
   Widget build(BuildContext context) {
@@ -63,7 +64,7 @@ class _AssetSelectionFieldState extends State<AssetSelectionField> {
           });
         },
         customDropdownButton: _buildAssetDropdownButton(),
-        dropdownChild: _buildAssetDropdownChild(),
+        dropdownChild: _buildAssetDropdownChild(_scrollController),
         chevronIcon: null,
         hintText: 'Select an asset',
         selectedItem: null,
@@ -140,7 +141,7 @@ class _AssetSelectionFieldState extends State<AssetSelectionField> {
   /// Builds the asset dropdown widget.
   ///
   /// Allows user to select from the list of existing assets in the wallet, i.e. [widget.assets].
-  Widget _buildAssetDropdownChild() {
+  Widget _buildAssetDropdownChild(ScrollController _scrollController) {
     return Container(
       decoration: BoxDecoration(
         color: const Color(0xffffffff),
@@ -154,9 +155,11 @@ class _AssetSelectionFieldState extends State<AssetSelectionField> {
         removeTop: true,
         child: Scrollbar(
           thumbVisibility: true,
+          controller: _scrollController,
           child: ListView(
             padding: const EdgeInsets.all(0),
             shrinkWrap: false,
+            controller: _scrollController,
             scrollDirection: Axis.vertical,
             children: widget.assets
                 .map(


### PR DESCRIPTION
Fixes an issue when closing the dropdown when selecting an asset

Included Error log:
```
======== Exception caught by scheduler library =====================================================
The following assertion was thrown during a scheduler callback:
A ScrollController is required when Scrollbar.thumbVisibility is true. The Scrollbar was not provided a ScrollController, and attempted to use the PrimaryScrollController, but none was found.
'package:flutter/src/widgets/scrollbar.dart':
Failed assertion: line 1496 pos 7: 'scrollController != null'


Either the assertion indicates an error in the framework itself, or we should provide substantially more information in this error message to help you determine and fix the underlying cause.
In either case, please report this assertion by filing a bug on GitHub:
  https://github.com/flutter/flutter/issues/new?template=2_bug.md

When the exception was thrown, this was the stack: 
#2      RawScrollbarState._debugCheckHasValidScrollPosition (package:flutter/src/widgets/scrollbar.dart:1496:7)
#3      RawScrollbarState._debugScheduleCheckHasValidScrollPosition.<anonymous closure> (package:flutter/src/widgets/scrollbar.dart:1456:14)
#4      SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1175:15)
#5      SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1113:9)
#6      SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:1015:5)
#7      _invoke (dart:ui/hooks.dart:148:13)
#8      PlatformDispatcher._drawFrame (dart:ui/platform_dispatcher.dart:318:5)
#9      _drawFrame (dart:ui/hooks.dart:115:31)
(elided 2 frames from class _AssertionError)
```